### PR TITLE
Adds support for OSX

### DIFF
--- a/src/relo.coffee
+++ b/src/relo.coffee
@@ -16,12 +16,16 @@ spawn = ->
   program = options.command[0]
   argv    = options.command[1..]
 
+  if ! argv.length && program.search(' ') != -1
+    [program, argv...] = program.split(' ')
+
   subproc = cp.spawn program, argv,
     cwd     : process.cwd()
-    stdio   : 'inherit'
     detached: true
 
   debug "Started #{program}"
+
+  subproc.stdout.on 'data', (buffer) -> console.log(buffer.toString().trim())
 
   subproc.on 'exit', (status, signal) ->
     debug "#{program} exited"


### PR DESCRIPTION
I ran into two problems trying to use relo on OSX, first `Invalid pid`:

<img width="973" alt="screen shot 2016-07-22 at 12 19 44" src="https://cloud.githubusercontent.com/assets/692077/17062104/ec407e92-5007-11e6-8931-101fab042130.png">

This was caused (presumably) by the process being called like this:

``` javascript
cp.spawn 'node somefile.js', []
```

instead of this:

```javascript
cp.spawn 'node', ['somefile.js']
```

After fixing that the problem was that the process died right after it began. Trying a bit I found that the problem seems to be `stdio`:

<img width="665" alt="screen shot 2016-07-22 at 12 26 31" src="https://cloud.githubusercontent.com/assets/692077/17062169/3586db78-5008-11e6-9f2b-9b83698486e2.png">

So instead of `inherit` for `stdio` I just piped the `data` buffer into `console.log`

I can't test it on Linux (or Windows) so I'm not sure if this changes are compatible.
